### PR TITLE
Use HueJay Timeout Value

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "huejay": "^0.11.0",
-    "mqtt": "^1.6.0"
+    "huejay": "^1.9.0",
+    "mqtt": "^3.0.0"
   }
 }

--- a/sensors.js
+++ b/sensors.js
@@ -10,7 +10,7 @@
 // sensors/hue/{unique_id}/get/buttons/down
 
 let sensors = {
-  timeout: 50,
+  timeout: 15000,
   sensors: {}
 };
 module.exports = sensors;


### PR DESCRIPTION
Previously a timeout of 50 was used, resulting in a 50ms timeout,
which is quite low and resulting in mqtt-hue hammering
Hue bridges that cannot respond to requests within that interval.
HueJays default timeout is 15000 (15s).
The added benefit of adjusting this is a more stable connection to
the Hue bridge as well as less CPU Usage on platforms such as Raspberry
Pi.